### PR TITLE
Add documentation for github-docs-agent sample

### DIFF
--- a/docs/sample.md
+++ b/docs/sample.md
@@ -1,0 +1,40 @@
+# GitHub Docs Agent Sample
+
+This document provides an overview of the GitHub Docs Agent sample, including its purpose, setup, usage, and expected outputs.
+
+## Purpose
+The GitHub Docs Agent sample demonstrates how to utilize the GitHub API to manage documentation within a repository. It showcases the capabilities of the agent in automating documentation tasks.
+
+## Requirements
+- Python 3.x
+- GitHub account with access to the repository
+- Required Python packages (e.g., requests)
+
+## Setup
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/UiPath/uipath-mcp-python.git
+   cd uipath-mcp-python
+   ```
+2. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Configure your GitHub token in the environment variables:
+   ```bash
+   export GITHUB_TOKEN=your_token_here
+   ```
+
+## Usage
+To run the GitHub Docs Agent sample, execute the following command:
+```bash
+python github_docs_agent.py
+```
+
+### Expected Outputs
+Upon successful execution, the agent will:
+- Create or update documentation files in the specified repository.
+- Log the actions taken during the process.
+
+## Conclusion
+This sample serves as a foundation for automating documentation tasks using the GitHub API. Modify and extend it according to your project's needs.


### PR DESCRIPTION
This PR adds documentation for the github-docs-agent sample as requested in issue #72. It includes details on purpose, setup, usage, and expected outputs.