### PR TITLE
log client info

### DIFF
--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -357,6 +357,8 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
                 }
                 client_info["tools"].append(tool_info)
 
+            logger.info(client_info)
+
             # Register with UiPath MCP Server
             await self._uipath.api_client.request_async(
                 "POST",
@@ -366,6 +368,9 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
             logger.info("Registered MCP Server type successfully")
         except Exception as e:
             logger.error(f"Error during registration: {e}")
+            if (e.status_code == 400):
+                logger.error(f"Error details: {e.response.text}")
+
             raise UiPathMcpRuntimeError(
                 "REGISTRATION_ERROR",
                 "Failed to register MCP Server",


### PR DESCRIPTION
Log the body and the request and response in case of 400 (to get validation errors from MCP servers)

Registering server runtime ...
**{'server': {'Name': 'env-server', 'Slug': 'env-server', 'Version': '1.0.0', 'Type': 3}, 'tools': [{'Name': 'return_env_var', 'ProcessType': 'Tool', 'Description': 'return env var'}, {'Name': 'echo', 'ProcessType': 'Tool', 'Description': ''}, {'Name': 'say', 'ProcessType': 'Tool', 'Description': 'say'}]}**
_HTTP Request: POST https://alpha.uipath.com/Ada/byoa/mcp_/mcp/env-server/runtime/start?runtimeId=e186a582-6267-4802-9969-a52de69b7941 "HTTP/1.1 400 Bad Request"_
Error during registration: Client error '400 Bad Request' for url 'https://alpha.uipath.com/Ada/byoa/mcp_/mcp/env-server/runtime/start?runtimeId=e186a582-6267-4802-9969-a52de69b7941'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
**Error details: {"type":"https://tools.ietf.org/html/rfc9110#section-15.5.1","title":"One or more validation errors occurred.","status":400,"errors":{"Tools[1].Description":["The Description field is required.","The field Description must be a string with a minimum length of 1 and a maximum length of 4000."]},"traceId":"00-69b769eb66887f23eeca50b885bdcf5b-f5f8a4b66276d2f3-00"}**
HTTP Request: POST https://alpha.uipath.com/Ada/byoa/llmopstenant_/api/Traces/spans?traceId=ebf08fe2-b5b8-4210-aae5-e4a226ec502d&source=Robots "HTTP/1.1 200 OK"