### PR TITLE
fix: register folder scoped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.87"
+version = "0.0.88"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -375,16 +375,25 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
 
             logger.info(client_info)
 
+            folder_key = os.environ.get("UIPATH_FOLDER_KEY")
+            if not folder_key:
+                raise UiPathMcpRuntimeError(
+                    "REGISTRATION_ERROR",
+                    "No UIPATH_FOLDER_KEY environment variable set.",
+                    UiPathErrorCategory.USER,
+                )
+
             # Register with UiPath MCP Server
             await self._uipath.api_client.request_async(
                 "POST",
                 f"mcp_/mcp/{self._server.name}/runtime/start?runtimeId={self._runtime_id}",
                 json=client_info,
+                headers={"X-UIPATH-FolderKey": folder_key},
             )
             logger.info("Registered MCP Server type successfully")
         except Exception as e:
             logger.error(f"Error during registration: {e}")
-            if (e.status_code == 400):
+            if e.status_code == 400:
                 logger.error(f"Error details: {e.response.text}")
 
             raise UiPathMcpRuntimeError(


### PR DESCRIPTION
## Pull Request Overview

This pull request fixes registration for folder-scoped execution by requiring the UIPATH_FOLDER_KEY environment variable before initiating the runtime registration.  
- Adds an environment variable check for UIPATH_FOLDER_KEY in the runtime registration process.  
- Updates the request header to include the folder key.  
- Bumps the project version from 0.0.87 to 0.0.88.