### PR TITLE
fix: update server types

### DIFF
--- a/src/uipath_mcp/_cli/_runtime/_context.py
+++ b/src/uipath_mcp/_cli/_runtime/_context.py
@@ -20,15 +20,15 @@ class UiPathServerType(Enum):
 
     Attributes:
         UiPath (0): Standard UiPath server for Processes, Agents, and Activities
-        External (1): External server types like npx, uvx
-        Local (2): Local MCP server (PackageType.MCPServer)
-        Hosted (3): Tunnel to externally hosted server
+        Command (1): Command server types like npx, uvx
+        Coded (2): Coded MCP server (PackageType.MCPServer)
+        SelfHosted (3): Tunnel to externally hosted server
     """
 
     UiPath = 0  # type: int # Processes, Agents, Activities
-    External = 1  # type: int # npx, uvx
-    Local = 2  # type: int # PackageType.MCPServer
-    Hosted = 3  # type: int # tunnel to externally hosted server
+    Command = 1  # type: int # npx, uvx
+    Coded = 2  # type: int # PackageType.MCPServer
+    SelfHosted = 3  # type: int # tunnel to externally hosted server
 
     @classmethod
     def from_string(cls, name: str) -> "UiPathServerType":
@@ -43,8 +43,8 @@ class UiPathServerType(Enum):
         """Get description for a server type."""
         descriptions = {
             cls.UiPath: "Standard UiPath server for Processes, Agents, and Activities",
-            cls.External: "External server types like npx, uvx",
-            cls.Local: "Local MCP server (PackageType.MCPServer)",
-            cls.Hosted: "Tunnel to externally hosted server",
+            cls.Command: "Command server types like npx, uvx",
+            cls.Coded: "Coded MCP server (PackageType.MCPServer)",
+            cls.SelfHosted: "Tunnel to externally hosted server",
         }
         return descriptions.get(server_type, "Unknown server type")

--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -286,8 +286,8 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
         server_stderr_output = ""
         env_vars = self._server.env
 
-        # if server is Local, include environment variables
-        if self.server_type is UiPathServerType.Local:
+        # if server is Coded, include environment variables
+        if self.server_type is UiPathServerType.Coded:
             for name, value in os.environ.items():
                 # config env variables should have precedence over system ones
                 if name not in env_vars:
@@ -553,12 +553,12 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
             UiPathServerType: The appropriate server type enum value based on the runtime configuration.
         """
         if self.packaged:
-            # If it's a packaged runtime (has a process_key), it's a Local server
+            # If it's a packaged runtime (has a process_key), it's a Coded server
             # Packaged runtimes are also sandboxed
-            return UiPathServerType.Local
+            return UiPathServerType.Coded
         elif self.sandboxed:
-            # If it's sandboxed but not packaged, it's an External server
-            return UiPathServerType.External
+            # If it's sandboxed but not packaged, it's a Command server
+            return UiPathServerType.Command
         else:
-            # If it's neither packaged nor sandboxed, it's a Hosted server
-            return UiPathServerType.Hosted
+            # If it's neither packaged nor sandboxed, it's a SelfHosted server
+            return UiPathServerType.SelfHosted


### PR DESCRIPTION
## Summary

This PR renames and remaps existing server categories, updating both the enum definitions and the runtime logic to use the new types.

- Renamed External, Local, and Hosted to Command, Coded, and SelfHosted in the enum and its descriptions
- Updated _runtime.py logic and comments to return and handle the new server types
- Adjusted environment‐variable injection to apply only to the Coded server type