### PR TITLE
fix: better error handling for invalid messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.93"
+version = "0.0.94"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -65,11 +65,12 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
             if self._server is None:
                 return None
 
-            self.trace_provider = TracerProvider()
-            trace.set_tracer_provider(self.trace_provider)
-            self.trace_provider.add_span_processor(
-                BatchSpanProcessor(LlmOpsHttpExporter())
-            )  # type: ignore
+            if self.context.job_id:
+                self.trace_provider = TracerProvider()
+                trace.set_tracer_provider(self.trace_provider)
+                self.trace_provider.add_span_processor(
+                    BatchSpanProcessor(LlmOpsHttpExporter())
+                )  # type: ignore
 
             # Set up SignalR client
             signalr_url = f"{os.environ.get('UIPATH_URL')}/agenthub_/wsstunnel?slug={self._server.name}&runtimeId={self._runtime_id}"


### PR DESCRIPTION
## Pull Request Overview
This PR improves error handling in the session runtime, conditions tracer initialization, and updates the package version.

- Wraps message processing in `_run_server` with a try/except to log errors and return a `JSONRPCError` to the client.
- Logs the server’s stderr output when capturing runtime errors.
- Only initializes the `OpenTelemetry` tracer if a `job_id` is present in the context.
- Bumps the project version from `0.0.93` to `0.0.94.`