### PR TITLE
Fix: Use FpsContext slug if available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.97"
+version = "0.0.98"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_mcp/_cli/_runtime/_context.py
+++ b/src/uipath_mcp/_cli/_runtime/_context.py
@@ -11,6 +11,33 @@ class UiPathMcpRuntimeContext(UiPathRuntimeContext):
 
     config: Optional[McpConfig] = None
     folder_key: Optional[str] = None
+    server_id: Optional[str] = None
+    server_slug: Optional[str] = None
+
+    @classmethod
+    def from_config(cls, config_path=None):
+        """Load configuration from uipath.json file with MCP-specific handling."""
+        # Use the parent's implementation
+        instance = super().from_config(config_path)
+
+        # Convert to our type (since parent returns UiPathRuntimeContext)
+        mcp_instance = cls(**instance.model_dump())
+
+        # Add AgentHub-specific configuration handling
+        import json
+        import os
+
+        path = config_path or "uipath.json"
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                config = json.load(f)
+
+            if "fpsContext" in config:
+                fps_context = config["fpsContext"]
+                mcp_instance.server_id = fps_context.get("Id")
+                mcp_instance.server_slug = fps_context.get("Slug")
+
+        return mcp_instance
 
 
 class UiPathServerType(Enum):


### PR DESCRIPTION
## Summary

This PR fixes the server identification mechanism to use the `FpsContext` slug when available, falling back to the server name when not present. This ensures that the correct server identifier is used for API calls and tracing operations.

- Uses `FpsContext` slug from configuration files as the primary server identifier
- Adds a new `slug` property to `UiPathMcpRuntime` that returns the `FpsContext` slug or falls back to server name
- Updates `SessionServer` constructor to accept and use the server slug parameter