### PR TITLE
Fix: Pass access token on SignalR connect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.98"
+version = "0.0.99"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -176,8 +176,12 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
                 root_span.set_attribute("args", json.dumps(self._server.args))
                 root_span.set_attribute("span_type", "MCP Server")
 
+                def token_factory() -> str:
+                    return os.environ.get("UIPATH_ACCESS_TOKEN", "")
+
                 self._signalr_client = SignalRClient(
                     signalr_url,
+                    access_token_factory=token_factory,
                     headers={
                         "X-UiPath-Internal-TenantId": self.context.trace_context.tenant_id,  # type: ignore
                         "X-UiPath-Internal-AccountId": self.context.trace_context.org_id,  # type: ignore


### PR DESCRIPTION
## Summary 

This PR fixes an authentication issue by ensuring the SignalR client receives the required access token during connection initialization. The change adds proper token authentication to the SignalR client configuration.

- Adds a token factory function that retrieves the access token from environment variables
- Updates SignalR client instantiation to include the access token factory parameter
- Bumps the package version to reflect this bug fix