### PR TITLE
fix(load_dotenv): remove load_dotenv()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.102"
+version = "0.0.103"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 dependencies = [
     "mcp==1.11.0",
     "pysignalr==1.3.0",
-    "uipath>=2.1.0, <2.2.0",
+    "uipath>=2.1.54, <2.2.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/uipath_mcp/_cli/_runtime/_context.py
+++ b/src/uipath_mcp/_cli/_runtime/_context.py
@@ -15,10 +15,12 @@ class UiPathMcpRuntimeContext(UiPathRuntimeContext):
     server_slug: Optional[str] = None
 
     @classmethod
-    def from_config(cls, config_path=None):
+    def from_config(
+        cls, config_path: str | None = None, **kwargs: object
+    ) -> "UiPathMcpRuntimeContext":
         """Load configuration from uipath.json file with MCP-specific handling."""
         # Use the parent's implementation
-        instance = super().from_config(config_path)
+        instance = super().from_config(config_path, **kwargs)
 
         # Convert to our type (since parent returns UiPathRuntimeContext)
         mcp_instance = cls(**instance.model_dump())

--- a/src/uipath_mcp/_cli/cli_run.py
+++ b/src/uipath_mcp/_cli/cli_run.py
@@ -3,7 +3,6 @@ import logging
 from os import environ as env
 from typing import Optional
 
-from dotenv import load_dotenv
 from uipath._cli._runtime._contracts import UiPathTraceContext
 from uipath._cli.middlewares import MiddlewareResult
 
@@ -13,7 +12,6 @@ from ._runtime._runtime import UiPathMcpRuntime
 from ._utils._config import McpConfig
 
 logger = logging.getLogger(__name__)
-load_dotenv()
 
 
 def mcp_run_middleware(


### PR DESCRIPTION
This pull request removes the use of the python-dotenv library and all calls to load_dotenv() from both sample scripts and the CLI utility code.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-mcp==0.0.103.dev1001480104",

  # Any version from PR
  "uipath-mcp>=0.0.103.dev1001480000,<0.0.103.dev1001490000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-mcp = { index = "testpypi" }
```