### PR TITLE
chore: add security scans

### DIFF
--- a/.pipelines/security-scans.yml
+++ b/.pipelines/security-scans.yml
@@ -1,0 +1,53 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 11 * * 1"
+    displayName: "Every Monday at 1:00 PM"
+    branches:
+      include:
+        - main
+    always: true
+
+resources:
+  repositories:
+    - repository: codeql
+      type: github
+      name: UiPath/AzurePipelinesTemplates
+      ref: refs/tags/uipath.security.codeql.1.9.5
+      endpoint: UiPath
+    - repository: fossa
+      type: github
+      name: UiPath/AzurePipelinesTemplates
+      ref: refs/tags/uipath.security.fossa.3.0.13
+      endpoint: UiPath
+
+variables:
+  - template: ./variables.yml
+
+stages:
+  - stage: FOSSA
+    dependsOn: []
+    jobs:
+      - job: FOSSA
+        steps:
+          - template: Security/fossa.steps.yml@fossa
+            parameters:
+              OS: linux
+              azureSubscription: $(azureInternalProductionEaConnectionName)
+              FOSSAFlags: '--project "UiPath MCP Python SDK" --branch "$(Build.SourceBranch)" --revision "$(Build.SourceVersion)-$(Build.BuildId)"'
+              FOSSATestFlags: '--project "UiPath MCP Python SDK" --revision "$(Build.SourceVersion)-$(Build.BuildId)"'
+              ${{ if contains(variables['Build.SourceBranch'], 'main') }}:
+                publishSecurityReports: true
+
+
+  - stage: CODEQL
+    dependsOn: []
+    jobs:
+      - job: CODEQL
+        steps:
+          - template: Security/codeql.interpreted.steps.yml@codeql
+            parameters:
+              os: 'linux64'
+              language: 'python'
+              azureSubscription: $(azureInternalProductionEaConnectionName)

--- a/.pipelines/variables.yml
+++ b/.pipelines/variables.yml
@@ -1,0 +1,2 @@
+variables:
+  azureInternalProductionEaConnectionName: Internal-Production-EA


### PR DESCRIPTION
# Description

Description
Add FOSSA and CODEQL scans to the CI pipeline. Scans should only run on merges to main and if the CI is manually run