### PR TITLE
fix: runtime error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-mcp"
-version = "0.0.104"
+version = "0.0.105"
 description = "UiPath MCP SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -402,8 +402,8 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
                             # Only proceed if initialization was successful
                             tools_result = await session.list_tools()
                             # logger.info(tools_result)
-                        except asyncio.TimeoutError:
-                            logger.error("Initialization timed out")
+                        except Exception as err:
+                            logger.error(f"Initialization error: {err}")
                             # Capture stderr output here, after the timeout
                             stderr_temp.seek(0)
                             server_stderr_output = stderr_temp.read()
@@ -418,7 +418,7 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
         # Now that we're outside the context managers, check if initialization succeeded
         if not initialization_successful:
             await self._on_runtime_abort()
-            error_message = "The server process failed to initialize. Verify environment variables are set correctly."
+            error_message = "The server process failed to initialize."
             if server_stderr_output:
                 error_message += f"\nServer error output:\n{server_stderr_output}"
             raise UiPathMcpRuntimeError(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -2145,7 +2145,7 @@ wheels = [
 
 [[package]]
 name = "uipath-mcp"
-version = "0.0.104"
+version = "0.0.105"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
This PR fixes unhandled exceptions during the `session.initialize()` step. Previously, only `asyncio.TimeoutError` was caught, causing other errors to go uncaught. As a result, the client would receive a misleading message:

`❌ The server process failed to initialize. Verify environment variables are set correctly.`

With this change, all initialization errors are now properly caught and handled, ensuring a more accurate error reporting.

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-mcp==0.0.105.dev1001530156",

  # Any version from PR
  "uipath-mcp>=0.0.105.dev1001530000,<0.0.105.dev1001540000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-mcp = { index = "testpypi" }
```