### PR TITLE
chore: update samples

### DIFF
--- a/samples/github-helper-agent/pyproject.toml
+++ b/samples/github-helper-agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "An automated agent that reviews GitHub pull requests and provides feedback"
 authors = [{ name = "Cristi Pufu", email = "cristian.pufu@uipath.com" }]
 dependencies = [
-    "uipath-langchain>=0.0.118",
+    "uipath-langchain>=0.0.118, <0.1.0",
     "langgraph>=0.5.4",
     "langchain-mcp-adapters>=0.1.9"
 ]

--- a/samples/github-slack-agent/pyproject.toml
+++ b/samples/github-slack-agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "An automated agent that reviews GitHub pull requests and provides feedback on Slack"
 authors = [{ name = "Cristi Pufu", email = "cristian.pufu@uipath.com" }]
 dependencies = [
-    "uipath-langchain>=0.0.118",
+    "uipath-langchain>=0.0.118, <0.1.0",
     "langgraph>=0.5.4",
     "langchain-mcp-adapters>=0.1.9"
 ]

--- a/samples/mcp-dynamic-server/pyproject.toml
+++ b/samples/mcp-dynamic-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "Dynamic MCP Server with self-extending tools"
 authors = [{ name = "John Doe" }]
 dependencies = [
-    "uipath-mcp>=0.0.101",
+    "uipath-mcp>=0.0.101, <0.1.0",
 ]
 requires-python = ">=3.11"

--- a/samples/mcp-functions-agent/pyproject.toml
+++ b/samples/mcp-functions-agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "A coder agent that implements and tests Python functions using a dynamic MCP server"
 authors = [{ name = "Cristi Pufu", email = "cristian.pufu@uipath.com" }]
 dependencies = [
-    "uipath-langchain>=0.0.118",
+    "uipath-langchain>=0.0.118, <0.1.0",
     "langgraph>=0.5.4",
     "langchain-mcp-adapters>=0.1.9"
 ]

--- a/samples/mcp-functions-server/pyproject.toml
+++ b/samples/mcp-functions-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "MCP Server that allows dynamic code functions creation and executions"
 authors = [{ name = "John Doe" }]
 dependencies = [
-    "uipath-mcp>=0.0.101",
+    "uipath-mcp>=0.0.101, <0.1.0",
 ]
 requires-python = ">=3.11"

--- a/samples/mcp-longrunning-server/pyproject.toml
+++ b/samples/mcp-longrunning-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "Long Running Operations MCP Server"
 authors = [{ name = "John Doe" }]
 dependencies = [
-    "uipath-mcp>=0.0.78",
+    "uipath-mcp>=0.0.78, <0.1.0",
 ]
 requires-python = ">=3.10"

--- a/samples/mcp-math-server/pyproject.toml
+++ b/samples/mcp-math-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "Advanced Math Operations MCP Server"
 authors = [{ name = "John Doe" }]
 dependencies = [
-    "uipath-mcp>=0.0.101",
+    "uipath-mcp>=0.0.101, <0.1.0",
 ]
 requires-python = ">=3.11"

--- a/samples/mcp-sdk-server/pyproject.toml
+++ b/samples/mcp-sdk-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 description = "Python SDK MCP Server"
 authors = [{ name = "John Doe" }]
 dependencies = [
-    "uipath-mcp>=0.0.101",
+    "uipath-mcp>=0.0.101, <0.1.0",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
Added upper version bounds (<0.1.0) to `uipath-mcp` and `uipath-langchain` dependencies across all sample projects to prevent breaking changes from future major versions.