### PR TITLE
fix: send FolderKey on mcp runtime abort

### DIFF
--- a/src/uipath_mcp/_cli/_runtime/_runtime.py
+++ b/src/uipath_mcp/_cli/_runtime/_runtime.py
@@ -573,6 +573,7 @@ class UiPathMcpRuntime(UiPathBaseRuntime):
             response = await self._uipath.api_client.request_async(
                 "POST",
                 f"agenthub_/mcp/{self.slug}/runtime/abort?runtimeId={self._runtime_id}",
+                headers={"X-UIPATH-FolderKey": self.context.folder_key},
             )
             if response.status_code == 202:
                 logger.info(


### PR DESCRIPTION
Send UiPath Folder Key header on mcp/.../runtime/abort - needed after https://github.com/UiPath/AgentHubService/pull/665

This will fix the issue reported here: https://uipath-product.slack.com/archives/C09MKT7TKRU/p1770280048276819