### PR TITLE
ci: add coverage report and sonarcloud scan on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
 
   test:
     uses: ./.github/workflows/test.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: Test
 
 on:
-  workflow_call
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: false
 
 jobs:
   test:
@@ -32,6 +35,51 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
+        if: "!(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')"
         run: uv run pytest
 
+      - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        run: uv run pytest --cov=src/uipath_mcp --cov-report=xml --cov-report=html --tb=short
+
+      - name: Upload coverage HTML report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-report
+          path: htmlcov/
+          retention-days: 30
+
+      - name: Upload coverage XML report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-report
+          path: coverage.xml
+          retention-days: 30
+
     continue-on-error: true
+
+  sonarcloud:
+    name: SonarCloud
+    needs: test
+    runs-on: ubuntu-latest
+    if: always() && needs.test.result != 'failure'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: coverage-xml-report
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,27 @@ python_files = "test_*.py"
 addopts = "-ra -q"
 asyncio_mode = "auto"
 
+[tool.coverage.run]
+source = ["src/uipath_mcp"]
+relative_files = true
+omit = [
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/site-packages/*",
+  "*/conftest.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "raise NotImplementedError",
+  "if TYPE_CHECKING:",
+  "@(abc\\.)?abstractmethod",
+]
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=UiPath_uipath-mcp-python
+sonar.organization=ui
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=src/uipath_mcp
+sonar.tests=tests
+
+sonar.python.version=3.11,3.12,3.13
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.exclusions=**/samples/**,**/testcases/**
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- adds `sonar-project.properties` and a `sonarcloud` job that runs after tests
- coverage runs only on the ubuntu/3.13 matrix cell and uploads xml + html artifacts