### PR TITLE
test: raise coverage to ~54% (from 32%)

### DIFF
--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -1,0 +1,79 @@
+"""Tests for the `uipath new` MCP middleware."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from uipath._cli.middlewares import MiddlewareResult
+
+from uipath_mcp._cli import cli_new
+
+
+def test_clean_directory_removes_only_py_files(tmp_path: Path):
+    (tmp_path / "a.py").write_text("x")
+    (tmp_path / "b.txt").write_text("x")
+    (tmp_path / "sub").mkdir()
+    cli_new.clean_directory(str(tmp_path))
+    assert not (tmp_path / "a.py").exists()
+    assert (tmp_path / "b.txt").exists()
+    assert (tmp_path / "sub").exists()
+
+
+def test_write_template_file_plain_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tpl").write_text("hello")
+    target = tmp_path / "out"
+    target.mkdir()
+    monkeypatch.setattr("uipath_mcp._cli.cli_new.os.path.dirname", lambda _: str(src))
+    cli_new.write_template_file(str(target), "tpl", "result.txt", None)
+    assert (target / "result.txt").read_text() == "hello"
+
+
+def test_write_template_file_with_replacements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tpl").write_text("name=$name; v=$v")
+    target = tmp_path / "out"
+    target.mkdir()
+    monkeypatch.setattr("uipath_mcp._cli.cli_new.os.path.dirname", lambda _: str(src))
+    cli_new.write_template_file(
+        str(target), "tpl", "result.txt", [("$name", "svc"), ("$v", "1")]
+    )
+    assert (target / "result.txt").read_text() == "name=svc; v=1"
+
+
+def test_generate_files_calls_write_three_times(tmp_path: Path):
+    with patch.object(cli_new, "write_template_file") as wtf:
+        cli_new.generate_files(str(tmp_path), "svc")
+    assert wtf.call_count == 3
+
+
+def test_mcp_new_middleware_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch.object(cli_new, "clean_directory") as cd,
+        patch.object(cli_new, "generate_files") as gf,
+    ):
+        result = cli_new.mcp_new_middleware("svc")
+    assert isinstance(result, MiddlewareResult)
+    assert result.should_continue is False
+    cd.assert_called_once()
+    gf.assert_called_once()
+
+
+def test_mcp_new_middleware_error_returns_stacktrace_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch.object(cli_new, "clean_directory", side_effect=OSError("boom")),
+        patch.object(cli_new.console, "error"),
+    ):
+        result = cli_new.mcp_new_middleware("svc")
+    assert result.should_continue is False
+    assert result.should_include_stacktrace is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,116 @@
+"""Tests for McpConfig and McpServer."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from uipath_mcp._cli._utils._config import McpConfig, McpServer
+
+
+def test_server_defaults():
+    s = McpServer("svc", {})
+    assert s.name == "svc"
+    assert s.type is None
+    assert s.transport == "stdio"
+    assert s.url is None
+    assert s.command == "None"
+    assert s.args == []
+    assert s.env == {}
+    assert s.file_path is None
+    assert s.is_streamable_http is False
+
+
+def test_server_streamable_http_and_args():
+    s = McpServer(
+        "svc",
+        {
+            "type": "remote",
+            "transport": "streamable-http",
+            "url": "https://x",
+            "command": "node",
+            "args": ["index.js"],
+            "env": {},
+        },
+    )
+    assert s.is_streamable_http is True
+    assert s.file_path == "index.js"
+    d = s.to_dict()
+    assert d["transport"] == "streamable-http"
+    assert d["url"] == "https://x"
+    assert d["command"] == "node"
+    assert "McpServer" in repr(s)
+
+
+def test_server_env_overlay_from_os(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("FOO", "from-env")
+    s = McpServer("svc", {"env": {"FOO": "default", "BAR": "keep"}})
+    assert s.env["FOO"] == "from-env"
+    assert s.env["BAR"] == "keep"
+
+
+def test_validate_server_name_ok():
+    McpConfig.validate_server_name("good-name-1")
+
+
+@pytest.mark.parametrize("bad", ["with space", "under_score", "dots.bad", ""])
+def test_validate_server_name_bad(bad: str):
+    with pytest.raises(ValueError):
+        McpConfig.validate_server_name(bad)
+
+
+def test_config_not_exists(tmp_path: Path):
+    cfg = McpConfig(str(tmp_path / "missing.json"))
+    assert cfg.exists is False
+    assert cfg.get_servers() == []
+    assert cfg.get_server_names() == []
+    assert cfg.get_server("anything") is None
+
+
+def test_config_load_and_lookup(tmp_path: Path):
+    path = tmp_path / "mcp.json"
+    path.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "alpha": {"command": "a", "args": ["a.py"]},
+                    "beta": {"command": "b"},
+                }
+            }
+        )
+    )
+    cfg = McpConfig(str(path))
+    assert cfg.exists is True
+    assert set(cfg.get_server_names()) == {"alpha", "beta"}
+    assert len(cfg.get_servers()) == 2
+    assert cfg.get_server("alpha").name == "alpha"  # type: ignore[union-attr]
+    assert cfg.get_server("missing") is None
+    raw = cfg.load_config()
+    assert "servers" in raw
+
+
+def test_config_single_server_returned_regardless_of_name(tmp_path: Path):
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"servers": {"only": {"command": "x"}}}))
+    cfg = McpConfig(str(path))
+    assert cfg.get_server("does-not-matter").name == "only"  # type: ignore[union-attr]
+
+
+def test_config_load_invalid_json(tmp_path: Path):
+    path = tmp_path / "mcp.json"
+    path.write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        McpConfig(str(path))
+
+
+def test_config_load_invalid_name(tmp_path: Path):
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps({"servers": {"bad name": {}}}))
+    with pytest.raises(ValueError):
+        McpConfig(str(path))
+
+
+def test_load_config_when_missing_raises(tmp_path: Path):
+    cfg = McpConfig(str(tmp_path / "nope.json"))
+    with pytest.raises(FileNotFoundError):
+        cfg.load_config()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,39 @@
+"""Tests for UiPathServerType enum."""
+
+import pytest
+
+from uipath_mcp._cli._runtime._context import UiPathServerType
+
+
+def test_enum_values():
+    assert UiPathServerType.UiPath.value == 0
+    assert UiPathServerType.Command.value == 1
+    assert UiPathServerType.Coded.value == 2
+    assert UiPathServerType.SelfHosted.value == 3
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["UiPath", "Command", "Coded", "SelfHosted"],
+)
+def test_from_string_valid(name: str):
+    assert UiPathServerType.from_string(name) == UiPathServerType[name]
+
+
+def test_from_string_invalid():
+    with pytest.raises(ValueError, match="Unknown server type"):
+        UiPathServerType.from_string("Nope")
+
+
+@pytest.mark.parametrize(
+    "server_type",
+    list(UiPathServerType),
+)
+def test_get_description_known(server_type: UiPathServerType):
+    desc = UiPathServerType.get_description(server_type)
+    assert isinstance(desc, str)
+    assert desc != "Unknown server type"
+
+
+def test_get_description_unknown():
+    assert UiPathServerType.get_description("not-an-enum") == "Unknown server type"  # type: ignore[arg-type]

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,28 @@
+"""Tests for UiPathMcpRuntimeError."""
+
+from uipath.runtime.errors import UiPathErrorCategory
+
+from uipath_mcp._cli._runtime._exception import McpErrorCode, UiPathMcpRuntimeError
+
+
+def test_error_code_values():
+    assert McpErrorCode.CONFIGURATION_ERROR.value == "CONFIGURATION_ERROR"
+    assert McpErrorCode.SERVER_NOT_FOUND.value == "SERVER_NOT_FOUND"
+    assert McpErrorCode.REGISTRATION_ERROR.value == "REGISTRATION_ERROR"
+    assert McpErrorCode.INITIALIZATION_ERROR.value == "INITIALIZATION_ERROR"
+
+
+def test_runtime_error_constructs_with_defaults():
+    err = UiPathMcpRuntimeError(McpErrorCode.CONFIGURATION_ERROR, "title", "detail")
+    assert isinstance(err, Exception)
+
+
+def test_runtime_error_constructs_with_all_args():
+    err = UiPathMcpRuntimeError(
+        McpErrorCode.SERVER_NOT_FOUND,
+        "title",
+        "detail",
+        UiPathErrorCategory.USER,
+        404,
+    )
+    assert isinstance(err, Exception)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,167 @@
+"""Tests for UiPathMcpRuntimeFactory."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uipath_mcp._cli._runtime import register_runtime_factory
+from uipath_mcp._cli._runtime._exception import UiPathMcpRuntimeError
+from uipath_mcp._cli._runtime._factory import UiPathMcpRuntimeFactory
+
+
+def _make_context(tmp_path: Path, config: dict[str, object] | None = None) -> MagicMock:
+    ctx = MagicMock()
+    cfg_path = tmp_path / "uipath.json"
+    if config is not None:
+        cfg_path.write_text(json.dumps(config))
+    ctx.config_path = str(cfg_path)
+    ctx.folder_key = "folder-key"
+    ctx.mcp_server_id = "server-id"
+    return ctx
+
+
+@pytest.fixture
+def factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    return UiPathMcpRuntimeFactory(context=_make_context(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_discover_entrypoints_empty_when_no_mcp_json(factory):
+    assert factory.discover_entrypoints() == []
+
+
+@pytest.mark.asyncio
+async def test_discover_entrypoints_returns_names(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(json.dumps({"servers": {"a": {}, "b": {}}}))
+    assert set(factory.discover_entrypoints()) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_raises_when_no_config(factory):
+    with pytest.raises(UiPathMcpRuntimeError):
+        await factory.new_runtime("a", "id")
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_raises_when_server_missing(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(json.dumps({"servers": {"a": {}, "b": {}}}))
+    factory._mcp_config = None
+    with pytest.raises(UiPathMcpRuntimeError):
+        await factory.new_runtime("missing", "id")
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_streamable_http_requires_url(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "a": {
+                        "transport": "streamable-http",
+                        "command": "node",
+                    }
+                }
+            }
+        )
+    )
+    factory._mcp_config = None
+    with pytest.raises(UiPathMcpRuntimeError, match="url"):
+        await factory.new_runtime("a", "id")
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_streamable_http_requires_command(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "a": {
+                        "transport": "streamable-http",
+                        "url": "https://x",
+                    }
+                }
+            }
+        )
+    )
+    factory._mcp_config = None
+    with pytest.raises(UiPathMcpRuntimeError, match="command"):
+        await factory.new_runtime("a", "id")
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_returns_runtime(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(json.dumps({"servers": {"a": {"command": "x"}}}))
+    factory._mcp_config = None
+    with patch("uipath_mcp._cli._runtime._factory.UiPathMcpRuntime") as rt_cls:
+        rt_cls.return_value = "RUNTIME"
+        result = await factory.new_runtime("a", "00000000-0000-0000-0000-000000000000")
+    assert result == "RUNTIME"
+    rt_cls.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_invalid_uuid_is_regenerated(tmp_path: Path, factory):
+    (tmp_path / "mcp.json").write_text(json.dumps({"servers": {"a": {"command": "x"}}}))
+    factory._mcp_config = None
+    with patch("uipath_mcp._cli._runtime._factory.UiPathMcpRuntime") as rt_cls:
+        await factory.new_runtime("a", "not-a-uuid")
+    kwargs = rt_cls.call_args.kwargs
+    # generated uuid should differ from the bad input
+    assert kwargs["runtime_id"] != "not-a-uuid"
+
+
+@pytest.mark.asyncio
+async def test_get_storage_returns_none(factory):
+    assert await factory.get_storage() is None
+
+
+@pytest.mark.asyncio
+async def test_get_settings_returns_none(factory):
+    assert await factory.get_settings() is None
+
+
+@pytest.mark.asyncio
+async def test_dispose_clears_config(factory):
+    factory._mcp_config = MagicMock()
+    await factory.dispose()
+    assert factory._mcp_config is None
+
+
+def test_mcp_slug_from_config(tmp_path: Path):
+    ctx = _make_context(
+        tmp_path,
+        {"runtime": {"fpsContext": {"mcpServer.slug": "from-config"}}},
+    )
+    factory = UiPathMcpRuntimeFactory(context=ctx)
+    assert factory._mcp_slug("entry") == "from-config"
+
+
+def test_mcp_slug_fallback_to_entrypoint(tmp_path: Path):
+    ctx = _make_context(tmp_path, {})
+    factory = UiPathMcpRuntimeFactory(context=ctx)
+    assert factory._mcp_slug("entry") == "entry"
+
+
+def test_mcp_slug_no_config_file(tmp_path: Path):
+    ctx = MagicMock()
+    ctx.config_path = str(tmp_path / "nope.json")
+    factory = UiPathMcpRuntimeFactory(context=ctx)
+    assert factory._mcp_slug("entry") == "entry"
+
+
+def test_register_runtime_factory_invokes_registry():
+    with patch("uipath_mcp._cli._runtime.UiPathRuntimeFactoryRegistry") as reg:
+        register_runtime_factory()
+    reg.register.assert_called_once()
+    args, _ = reg.register.call_args
+    assert args[0] == "mcp"
+    assert args[2] == "mcp.json"
+    # invoke the factory builder with and without a context
+    create_factory = args[1]
+    with patch("uipath_mcp._cli._runtime.UiPathMcpRuntimeFactory") as fc:
+        create_factory(None)
+        create_factory(MagicMock())
+    assert fc.call_count == 2

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,15 @@
+"""Tests for the middleware registration entry point."""
+
+from unittest.mock import patch
+
+from uipath._cli.middlewares import Middlewares
+
+from uipath_mcp import middlewares
+
+
+def test_register_middleware_registers_new():
+    with patch.object(Middlewares, "register") as reg:
+        middlewares.register_middleware()
+    reg.assert_called_once()
+    args, _ = reg.call_args
+    assert args[0] == "new"

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,139 @@
+"""Tests for McpTracer."""
+
+import logging
+from unittest.mock import MagicMock
+
+import mcp.types as types
+import pytest
+
+from uipath_mcp._cli._runtime._tracer import McpTracer
+
+
+@pytest.fixture
+def fake_span() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def tracer_with_fake_span(fake_span: MagicMock) -> McpTracer:
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+    return McpTracer(tracer=fake_tracer, logger=logging.getLogger("test"))
+
+
+def _req(id_: int, method: str, params=None) -> types.JSONRPCMessage:
+    return types.JSONRPCMessage(
+        types.JSONRPCRequest(jsonrpc="2.0", id=id_, method=method, params=params)
+    )
+
+
+def _notif(method: str, params=None) -> types.JSONRPCMessage:
+    return types.JSONRPCMessage(
+        types.JSONRPCNotification(jsonrpc="2.0", method=method, params=params)
+    )
+
+
+def _resp(id_: int, result=None) -> types.JSONRPCMessage:
+    return types.JSONRPCMessage(
+        types.JSONRPCResponse(jsonrpc="2.0", id=id_, result=result or {})
+    )
+
+
+def _err(id_: int) -> types.JSONRPCMessage:
+    return types.JSONRPCMessage(
+        types.JSONRPCError(
+            jsonrpc="2.0",
+            id=id_,
+            error=types.ErrorData(code=-1, message="boom"),
+        )
+    )
+
+
+def test_default_init():
+    t = McpTracer()
+    assert t._tracer is not None
+    assert t._logger is not None
+    assert t._active_request_spans == {}
+
+
+def test_request_span(tracer_with_fake_span):
+    span = tracer_with_fake_span.create_span_for_message(
+        _req(1, "tools/call", {"name": "x", "arguments": {"k": "v"}}),
+        custom="ctx",
+    )
+    assert span is not None
+    assert "1" in tracer_with_fake_span._active_request_spans
+
+
+def test_request_span_resources_read(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(
+        _req(2, "resources/read", {"uri": "file://x"})
+    )
+
+
+def test_request_span_prompts_get(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(_req(3, "prompts/get", {"name": "p"}))
+
+
+def test_notification_span(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(
+        _notif(
+            "notifications/progress",
+            {"progress": 0.5, "total": 1.0},
+        )
+    )
+
+
+def test_notification_resource_updated(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(
+        _notif("notifications/resources/updated", {"uri": "file://x"})
+    )
+
+
+def test_notification_cancelled(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(
+        _notif("notifications/cancelled", {"requestId": "1", "reason": "user"})
+    )
+
+
+def test_response_creates_orphan_span(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(_resp(99, {"ok": True}))
+
+
+def test_response_attaches_to_active_request(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(_req(7, "tools/call"))
+    tracer_with_fake_span.create_span_for_message(_resp(7, {"ok": True}))
+    assert "7" not in tracer_with_fake_span._active_request_spans
+
+
+def test_error_orphan_span(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(_err(50))
+
+
+def test_error_correlates_with_active_request(tracer_with_fake_span):
+    tracer_with_fake_span.create_span_for_message(_req(8, "tools/call"))
+    tracer_with_fake_span.create_span_for_message(_err(8))
+    assert "8" not in tracer_with_fake_span._active_request_spans
+
+
+def test_record_http_error(tracer_with_fake_span, fake_span):
+    tracer_with_fake_span.record_http_error(fake_span, 500, "oops")
+    fake_span.set_status.assert_called()
+
+
+def test_record_exception(tracer_with_fake_span, fake_span):
+    tracer_with_fake_span.record_exception(fake_span, RuntimeError("x"))
+    fake_span.set_status.assert_called()
+
+
+def test_create_operation_span(tracer_with_fake_span):
+    span = tracer_with_fake_span.create_operation_span("op", k="v")
+    assert span is not None
+
+
+def test_get_current_span(tracer_with_fake_span):
+    assert tracer_with_fake_span.get_current_span() is not None
+
+
+def test_add_event_to_current_span(tracer_with_fake_span):
+    tracer_with_fake_span.add_event_to_current_span("evt", k="v")


### PR DESCRIPTION
## Summary
- new test files for `_context`, `_exception`, `_config`, `cli_new`, `middlewares`, `_factory`, `_tracer`
- those 7 modules now sit at 100% (tracer 97.6%), overall coverage moves from 32.10% to 53.85%

## Why

first follow-up from #210. remaining gap is concentrated in `_runtime.py`, `_session.py`, and `_token_refresh.py`, which need deeper async/IO mocking and will land in subsequent PRs.