### PR TITLE
chore: enforce 2-day minimum age for non-uipath packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,15 @@ exclude_lines = [
   "@(abc\\.)?abstractmethod",
 ]
 
+[tool.uv]
+exclude-newer = "2 days"
+
+[tool.uv.exclude-newer-package]
+uipath = false
+uipath-core = false
+uipath-platform = false
+uipath-runtime = false
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,16 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
+[options.exclude-newer-package]
+uipath = false
+uipath-platform = false
+uipath-runtime = false
+uipath-core = false
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -1784,7 +1794,7 @@ wheels = [
 
 [[package]]
 name = "uipath-mcp"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
prudent against supply chain attacks.