### PR TITLE
fix(ci): restore coverage reporting after runner label migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,15 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
-        if: "!(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13')"
+        if: "!(endsWith(matrix.os, 'ubuntu-latest') && matrix.python-version == '3.13')"
         run: uv run pytest
 
       - name: Run tests with coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: endsWith(matrix.os, 'ubuntu-latest') && matrix.python-version == '3.13'
         run: uv run pytest --cov=src/uipath_mcp --cov-report=xml --cov-report=html --tb=short
 
       - name: Upload coverage HTML report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        if: endsWith(matrix.os, 'ubuntu-latest') && matrix.python-version == '3.13' && always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-html-report
@@ -51,7 +51,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage XML report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && always()
+        if: endsWith(matrix.os, 'ubuntu-latest') && matrix.python-version == '3.13' && always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-xml-report


### PR DESCRIPTION
## Problem

SonarCloud has reported **0% coverage** on `main` since 2026-08-06, which re-opened the MER code-coverage KPI ([PRODEV-612](https://uipath.atlassian.net/browse/PRODEV-612)).

[PR #246](https://github.com/UiPath/uipath-mcp-python/pull/246) renamed the test matrix runners:

```yaml
os: [uipath-ubuntu-latest, uipath-windows-latest]   # renamed
```

but the step conditions still compare against the **old** labels:

```yaml
if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'   # never true now
```

So on every run since:

1. `Run tests with coverage` → **skipped**
2. `Upload coverage XML report` → **skipped** (no artifact)
3. `Download coverage` in the `sonarcloud` job → misses it, swallowed by `continue-on-error: true`
4. SonarCloud scans with no report → **0% coverage**

CI stayed ✅ green because the inverse condition `!(...)` became always-true, so plain `pytest` ran on all six combinations.

Evidence from the Aug-6 run (`test / Test (3.13, uipath-ubuntu-latest)`):

```
success   Run tests
skipped   Run tests with coverage
skipped   Upload coverage XML report
```

## Fix

Use `endsWith(matrix.os, 'ubuntu-latest')` so the conditions match both the current `uipath-` prefixed labels and any future prefix change.

Exactly one job (`uipath-ubuntu-latest` + Python 3.13) produces coverage again — same as the original design.

## Verification

Tests are unaffected — only the CI plumbing broke. On this commit, locally:

- `203 passed`
- **coverage 98.39%** (1177 stmts, 19 missed)

After merge, the SonarCloud analysis on `main` should return to ~98%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRODEV-612]: https://uipath.atlassian.net/browse/PRODEV-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ